### PR TITLE
Adding a message to the README about Flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ For the path: check where the binaries are located and add these to "/private/et
 ##### Arch / Manjaro
 - Run `sudo pacman -S tesseract graphicsmagick ghostscript`
 - Install any languages you need by installing the appropriate package (usually named `tesseract-data-<lang>`)
+
+Note - if Obsidian is running via the Flatpak installation (such as provided by default in Pop!_OS) then this plugin will not operate. Flatpak sandboxing will change the filepaths so even providing host access will still be problematic. If you have a Flatpak installation you will need to reinstall via a different method to successfully use this plugin.
+
 ### Usage
 - On startup / when adding a new file the file is automatically getting searched for text.
 - Use the `magnifying glass` in the ribbon / the `Search OCR` command to perform the search.


### PR DESCRIPTION
I tried all sorts of things to get this to work on my System76 computer. I went so far as to add settings to specify the path to the binaries. Turns out that Flatpak with its sandboxing and path rewriting makes this impossible or at least to hard to bother with. Even telling it /var/run/usr/bin/tesseract as the path, it failed on trying to find the libraries since they are linked in /usr/lib. Bleh.

The real solution is to let people using Flatpak know that it is incompatible with this plugin. 