### PR TITLE
Start search modal empty 

### DIFF
--- a/src/modals/SearchModal.ts
+++ b/src/modals/SearchModal.ts
@@ -49,6 +49,7 @@ export default class SearchModal extends SuggestModal<Page> {
 
 	getSuggestions(query: string): Page[] | Promise<Page[]> {
 		this.query = query;
+		if (!query) return [];
 		if (SettingsManager.currentSettings.fuzzySearch) {
 			return fuzzy.filter(query, this.pages, {
 				extract: (page: Page) => {


### PR DESCRIPTION
The current strategy of opening the modal with everything can bog down with many images and is a bit confusing as to why there results. I suggest starting with an empty array when there is no query. 