### PR TITLE
Slider timeout

### DIFF
--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -31,7 +31,7 @@ export class SettingsTab extends PluginSettingTab {
 			});
 		}).setName("OCR PDF").setDesc("Whether PDFs should be OCRed");
 		new Setting(ocrProviderDropdownDiv).addSlider((slider) => {
-			slider.setLimits(1,50,1);
+			slider.setLimits(1,10,1);
 			slider.setValue(SettingsManager.currentSettings.concurrentProcesses);
 			slider.setDynamicTooltip();
 			slider.onChange(async (value) => {

--- a/src/utils/OcrQueue.ts
+++ b/src/utils/OcrQueue.ts
@@ -6,12 +6,14 @@ import SettingsManager from "../Settings";
 import { processFile } from "./FileOps";
 import Transcript from "../hocr/Transcript";
 import { isFileOCRable } from "./FileUtils";
+import { clearTimeout, setTimeout } from "timers";
 
 
 
 export class OcrQueue {
 
 	static ocrQueue: QueueObject<File>;
+	static processChangeTimer: NodeJS.Timeout;
 
 	public static getQueue() {
 		this.ocrQueue = this.ocrQueue || async.queue(async function (file, callback) {
@@ -32,8 +34,15 @@ export class OcrQueue {
 		StatusBar.addIndexingFile(file);
 	}
 
+	public static _changeMaxProcesses(processes: number) {
+		OcrQueue.getQueue().concurrency = processes;
+	}
+
 	public static changeMaxProcesses(processes: number) {
-		this.getQueue().concurrency = processes;
+		if (this.processChangeTimer) {
+			clearTimeout(this.processChangeTimer);
+		}
+		this.processChangeTimer = setTimeout(this._changeMaxProcesses, 10000, processes);
 	}
 
 


### PR DESCRIPTION
Reduced that max concurrency in the slider to 10 because 

1. 50 is crazy and
2. Having too many steps makes it hard to find the number you are looking for.

I added a timeout in changeMaxProcesses() so that it will take 10 seconds of no changes before the actual change occurs. This should greatly reduce or eliminate spawning more processes than intended. During testing of a different branch I did it to myself again and hated life.