### PR TITLE
Create event on toggle change

### DIFF
--- a/src/modals/SearchModal.ts
+++ b/src/modals/SearchModal.ts
@@ -28,6 +28,7 @@ export default class SearchModal extends SuggestModal<Page> {
 				tc.onChange(async (value) => {
 					SettingsManager.currentSettings.fuzzySearch = value;
 					await SettingsManager.saveSettings();
+					this.inputEl.dispatchEvent(new Event("input", {}));
 				});
 			});
 		new Setting(this.modalEl)
@@ -38,6 +39,7 @@ export default class SearchModal extends SuggestModal<Page> {
 				tc.onChange(async (value) => {
 					SettingsManager.currentSettings.caseSensitive = value;
 					await SettingsManager.saveSettings();
+					this.inputEl.dispatchEvent(new Event("input", {}));
 				});
 			});
 		console.profileEnd();


### PR DESCRIPTION
When changing the fuzzy search or case sensitive toggles, dispatch a fake input event to the input box. This makes it think new text has been entered and redo the search. Because the toggle has changed, the new search will be run with the parameters that have been selected. This way, you see immediate effect. It was odd UX to change the event and see nothing different until you changed the text.

PS - I'm over my 4 pull requests for Hacktoberfest. I'm not sending multiples to increase the count, I'm trying to isolate different bits of functionality in different PRs so that you can accept or reject them individually. I'm having fun and want this plugin as good as possible, so feel free to assign me work if you want to.