### PR TITLE
Use the stored settings in the search modal

### DIFF
--- a/src/modals/SearchModal.ts
+++ b/src/modals/SearchModal.ts
@@ -24,7 +24,7 @@ export default class SearchModal extends SuggestModal<Page> {
 			.setName("Fuzzy search")
 			.setDesc("Enable or disable fuzzy search")
 			.addToggle((tc) => {
-				tc.setValue(true);
+				tc.setValue(SettingsManager.currentSettings.fuzzySearch );
 				tc.onChange(async (value) => {
 					SettingsManager.currentSettings.fuzzySearch = value;
 					await SettingsManager.saveSettings();
@@ -34,7 +34,7 @@ export default class SearchModal extends SuggestModal<Page> {
 			.setName("Case sensitive")
 			.setDesc("Enable or disable case sensitivity")
 			.addToggle((tc) => {
-				tc.setValue(true);
+				tc.setValue(SettingsManager.currentSettings.caseSensitive);
 				tc.onChange(async (value) => {
 					SettingsManager.currentSettings.caseSensitive = value;
 					await SettingsManager.saveSettings();


### PR DESCRIPTION
When changing the options, they are saved to SettingsManager.currentSettings but on the next invocation both toggles are always set to true. Instead, use the value from SettingsManager to retain the persisted options.