### PR TITLE
When deleting folders rebuild the TranscriptCache

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -32,7 +32,10 @@ export default class ObsidianOCRPlugin extends Plugin {
 			OcrQueue.enqueueFile(file);
 		}));
 		this.registerEvent(this.app.vault.on("delete", async (tFile) => {
-			if (tFile instanceof TFolder) return;
+			if (tFile instanceof TFolder) {
+				TranscriptCache.rebuildCache();
+				return;
+			}
 			const file = File.fromFile(tFile as TFile);
 			if (file.jsonFile && existsSync(file.jsonFile.absPath)) {
 				TranscriptCache.remove(await Transcript.load(file.jsonFile.absPath));

--- a/src/TranscriptCache.ts
+++ b/src/TranscriptCache.ts
@@ -73,4 +73,9 @@ export default abstract class TranscriptCache {
 		if (TranscriptCache.populated) return TranscriptCache.cacheBackend;
 		return TranscriptCache.toAdd;
 	}
+
+	static rebuildCache() {
+		TranscriptCache.cacheBackend = [];
+		TranscriptCache.populate();
+	}
 }


### PR DESCRIPTION
Currently the delete event handler completely skips the case when the deleted thing is TFolder. However, that leaves behind in the TranscriptCache everything that was in that folder. I added a complete rebuild of the cache on any folder deletion because you can't tell otherwise what is still really around. I don't know if the file specs can be iterated because they have been deleted so it seems simpler to just rebuild everything.